### PR TITLE
Make package compatible with AGP8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,6 +39,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.zemlyanikinmaksim.app_install_date'	
     compileSdkVersion 30
 
     sourceSets {


### PR DESCRIPTION
When trying to use com.android.tools.build:gradle:8.0.0

I get: 
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Please specify a namespace in the module's build.gradle file like so:

     android {
         namespace 'com.example.namespace'
     }

     If the package attribute is specified in the source AndroidManifest.xml, it can be migrated automatically to the namespace value in the build.gradle file using the AGP Upgrade Assistant; please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.

This change solves that problem
