### PR TITLE
Updating gradle settings to provide support for AGP8+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        //bumping gradle to 7.3 
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,9 +43,9 @@ android {
     compileSdkVersion 30
     
     // Conditional for compatibility with AGP <4.2.
-    //if (project.android.hasProperty("namespace")) {
+    if (project.android.hasProperty("namespace")) {
         namespace 'com.zemlyanikinmaksim.app_install_date'	
-    //}
+    }
     
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,6 +40,20 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 30
+    
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.zemlyanikinmaksim.app_install_date'	
+    }
+    
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,9 +43,9 @@ android {
     compileSdkVersion 30
     
     // Conditional for compatibility with AGP <4.2.
-    if (project.android.hasProperty("namespace")) {
+    //if (project.android.hasProperty("namespace")) {
         namespace 'com.zemlyanikinmaksim.app_install_date'	
-    }
+    //}
     
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: app_install_date
 description: This plugin helps you to get install date of the application
-version: 0.1.2
+version: 0.1.3
 homepage: https://github.com/Maksimka101/app_install_date
 
 environment:


### PR DESCRIPTION
Change version to 0.1.3
Added conditional statement for namespace to allow backwards compatibility for the AGP8+ fix
Added compile options for Java
Bumped  Gradle version to 7.3 as per https://docs.gradle.org/current/userguide/compatibility.html